### PR TITLE
Update playwright.md Fix typo

### DIFF
--- a/instruction/playwright/playwright.md
+++ b/instruction/playwright/playwright.md
@@ -218,7 +218,7 @@ Before we can write our own tests we need to finish configuring Playwright. Open
   },
 ```
 
-You can also remove all the comments in order to make the file easier to read. When you are done your configuration file should look like the following. Make sure you understand what all of this [configuration](https://playwright.dev/docs/test-configuration) is doing so that you can maximum the value that Playwright provides.
+You can also remove all the comments in order to make the file easier to read. When you are done your configuration file should look like the following. Make sure you understand what all of this [configuration](https://playwright.dev/docs/test-configuration) is doing so that you can maximize the value that Playwright provides.
 
 ```js
 import { defineConfig, devices } from '@playwright/test';


### PR DESCRIPTION
This change duplicates a change proposed in #68. The reviewer can choose which edition of the two lines to keep in the final edition.

## Raw Edition Comparisons
#### 
> … **get the maximum value** that Playwright provides #68 
> https://github.com/devops329/devops/blob/ea9cbc6a0f6535af07250a72cb96f299ded62b02/instruction/playwright/playwright.md?plain=1#L221

#### 
> … **maximum the value** that Playwright provides #69 
>  https://github.com/devops329/devops/blob/48b815b8edf838476fa31243b3e08fde1d96eef6/instruction/playwright/playwright.md?plain=1#L221