### PR TITLE
Improve usability of AWS S3 instructions

### DIFF
--- a/instruction/awsS3/awsS3.md
+++ b/instruction/awsS3/awsS3.md
@@ -104,7 +104,7 @@ You are going to use S3 to statically host the JWT Pizza static frontend code th
 
 Create an S3 bucket and copy a file into the bucket.
 
-1. Open the AWS browser console and navigate to the S3 service.
+1. Open the AWS browser console and navigate to the [S3 service](https://console.aws.amazon.com/s3/buckets).
 1. Click on the `Create bucket` button.
 1. Select the `General configuration` option and name it something unique. Remember that the bucket namespace is global, and so you cannot use a name that already is in use.
 

--- a/instruction/awsS3/awsS3.md
+++ b/instruction/awsS3/awsS3.md
@@ -115,8 +115,8 @@ Create an S3 bucket and copy a file into the bucket.
 1. Drag a file from your development environment and drop it on the `Upload` target.
 1. Press the `Upload` button and then press the `Close` button to return to the bucket view.
 
-Take a screenshot of the bucket with your file in it and submit it to the Canvas assignment. Your screenshot should look something like the following.
+1. Take a screenshot of the bucket with your file in it and submit it to the Canvas assignment. Your screenshot should look something like the following.
 
-![Bucket with file](bucketWithFile.png)
+   ![Bucket with file](bucketWithFile.png)
 
-Once you are done you can go ahead and delete all the files in the bucket and then delete the bucket itself.
+1. Once you are done you can go ahead and delete all the files in the bucket and then delete the bucket itself. Deleting the bucket can be done from the [S3 bucket page](https://console.aws.amazon.com/s3/buckets) (the parent page).

--- a/instruction/awsS3/awsS3.md
+++ b/instruction/awsS3/awsS3.md
@@ -27,13 +27,11 @@ At a basic level S3 is just a global list of bucket names that each contain a po
 
 It doesn't actually have a directory structure or path, but objects with the same prefix will appear to be associated. Additionally, the `/` character is treated as special by many tools. This allows them to display and navigate them as directories, when in reality it is just another character in the name.
 
-## Creating S3 Buckets
-Help!
-[... I've never created AWS resources before. Now that I understand the concept of AWS S3, I still don't have any instances in my account. I pulled up the cloudshell console and typed `aws s3 ls`, but it just spun forever and never resolved. I expect that I need to create a bucket first, but I don't know which of AWS's bajillion pages to use to do so.]
-
-TODO: Provide instructions, or references to instructions here about orienting myself with AWS.
-
 ## Accessing S3 files
+
+> [!TIP]
+> Read the introductory information before attempting to follow along.\
+> Detailed instructions are included at the end as part of the [assignment](#assignment).
 
 You can experiment with S3 by using the AWS Browser console interface, or with the AWS CLI from your command console. For example, you can list all the AWS S3 buckets that are owned by your account with the `ls` command. Make sure you have the AWS CLI installed in your development environment with an associated access key. Otherwise, you can use the [AWS CloudShell service](https://aws.amazon.com/cloudshell/) from the AWS Browser Console to experiment with these commands.
 
@@ -100,7 +98,7 @@ You are going to use S3 to statically host the JWT Pizza static frontend code th
 
 ![CloudFront access](cloudFrontAccess.png)
 
-## ☑ Assignment
+## <a name="assignment"></a> ☑ Assignment
 
 Create an S3 bucket and copy a file into the bucket.
 

--- a/instruction/awsS3/awsS3.md
+++ b/instruction/awsS3/awsS3.md
@@ -27,6 +27,12 @@ At a basic level S3 is just a global list of bucket names that each contain a po
 
 It doesn't actually have a directory structure or path, but objects with the same prefix will appear to be associated. Additionally, the `/` character is treated as special by many tools. This allows them to display and navigate them as directories, when in reality it is just another character in the name.
 
+## Creating S3 Buckets
+Help!
+[... I've never created AWS resources before. Now that I understand the concept of AWS S3, I still don't have any instances in my account. I pulled up the cloudshell console and typed `aws s3 ls`, but it just spun forever and never resolved. I expect that I need to create a bucket first, but I don't know which of AWS's bajillion pages to use to do so.]
+
+TODO: Provide instructions, or references to instructions here about orienting myself with AWS.
+
 ## Accessing S3 files
 
 You can experiment with S3 by using the AWS Browser console interface, or with the AWS CLI from your command console. For example, you can list all the AWS S3 buckets that are owned by your account with the `ls` command. Make sure you have the AWS CLI installed in your development environment with an associated access key. Otherwise, you can use the [AWS CloudShell service](https://aws.amazon.com/cloudshell/) from the AWS Browser Console to experiment with these commands.


### PR DESCRIPTION
As an experienced programmer and linux user, but brand new user to AWS systems, I was totally lost. 

* When I saw code blocks, I assumed I could be following along, but that lead to issues since I didn't yet have a storage bucket to operate on.
* Additionally, AWS is a massive system and I had no idea where to find the starting pages for the S3 instructions. Direct links were added to help future students. Further adjustments could include instruction on searching for S3 in the toolbar.
* I promise I'm not stupid, but I am brand new to the AWS system and I (and likely other students too) need additional help to get oriented in this new space.