### PR TITLE
Remove typo from deploymentEnvironments.md

### DIFF
--- a/instruction/deploymentEnvironments/deploymentEnvironments.md
+++ b/instruction/deploymentEnvironments/deploymentEnvironments.md
@@ -12,7 +12,7 @@ To this point you have been deploying your code directly to your production envi
 ```yml
 - name: Push to AWS S3
   run: |
-    aws s3 cp dist s3://pizza.byucsstudent.click/$version --recursive
+    aws s3 cp dist s3://pizza.byucsstudent.click --recursive
 ```
 
 This has several problems. First, it just copies the deployment package files directly into the S3 location that CloudFront hosts to the world using your application URL. That means that old files that are no longer used by the application (and therefore will not be overwritten by copying) are still available for public access. This creates a security, as well as a maintenance problem.


### PR DESCRIPTION
I believe this is a typo, since it is supposed to be an example of our aws s3 cp command before we implement the version subdirectories