### PR TITLE
Update awsEcr.md Provide Provenance flag to avoid "three artifact" behavior

### DIFF
--- a/instruction/awsEcr/awsEcr.md
+++ b/instruction/awsEcr/awsEcr.md
@@ -31,9 +31,9 @@ Using the process that you executed in the previous instruction about how to bui
 
 ⚠️ **Note**: You must have the [AWS CLI installed](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) before you execute the next steps. If you have not done that yet, then go and do it now.
 
-1. Follow the steps that you previously used to build the **jwt-pizza-service** container (including navigating to the `dist` folder before building the container). However, this time specify the target platform of (`linux/arm64`) since that is the operating system you will use when you deploy the container to AWS.
+1. Follow the steps that you previously used to build the **jwt-pizza-service** container (including navigating to the `dist` folder before building the container). However, this time specify the target platform of (`linux/arm64`) since that is the operating system you will use when you deploy the container to AWS. Additionally, including the [`--provenance=false`](https://stackoverflow.com/a/77207574/2844859) flag avoids a behavior that appears to upload _three items_ into your AWS ECR account in subsequent steps.
    ```sh
-   docker build  --platform=linux/arm64 -t jwt-pizza-service .
+   docker build --platform=linux/arm64 --provenance=false -t jwt-pizza-service .
    ```
 1. Open the AWS browser console and navigate to the Elastic Container Registry (ECR) service.
 1. Open the repository you created in the earlier step.

--- a/instruction/awsEcr/awsEcr.md
+++ b/instruction/awsEcr/awsEcr.md
@@ -31,7 +31,7 @@ Using the process that you executed in the previous instruction about how to bui
 
 ⚠️ **Note**: You must have the [AWS CLI installed](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) before you execute the next steps. If you have not done that yet, then go and do it now.
 
-1. Follow the steps that you previously used to build the **jwt-pizza-service** container (including navigating to the `dist` folder before building the container). However, this time specify the target platform of (`linux/arm64`) since that is the operating system you will use when you deploy the container to AWS. Additionally, including the [`--provenance=false`](https://stackoverflow.com/a/77207574/2844859) flag avoids a behavior that appears to upload _three items_ into your AWS ECR account in subsequent steps.
+1. Follow the steps that you previously used to build the **jwt-pizza-service** container (including navigating to the `dist` folder before building the container). However, this time specify the target platform of (`linux/arm64`) since that is the operating system you will use when you deploy the container to AWS. The `--provenance=false` parameter reduces the bookkeeping information that is uploaded to the container registry.
    ```sh
    docker build --platform=linux/arm64 --provenance=false -t jwt-pizza-service .
    ```


### PR DESCRIPTION
## Overview
Provide and document the [`--provenance=false`](https://stackoverflow.com/a/77207574/2844859) flag which avoids future confusion.

## Discussion
By default, _on at least some systems_, following the recommended procedures results in **multiple** artifacts being upload the AWS ECR for a single push event. These are harmless and don't cause any problems, but they are confusing. This behavior was observed by myself and multiple other students.

## Screenshot
A screenshot originally posted by **Harrison Casper** showing the downstream behavior that occurs without this flag.
![image](https://github.com/user-attachments/assets/bbe9e90c-7db4-40fa-9903-475a67120ba2)


## Credit
The solution was originally shared with the class by **Seth Ramer**, who posted about it [in Discord](https://discord.com/channels/1251010889575039117/1298091715777007719/1298511177688682540).