### PR TITLE
Update awsEcr.md Help Students avoid "Circuit Breaker Triggered" Errors

### DIFF
--- a/instruction/awsEcr/awsEcr.md
+++ b/instruction/awsEcr/awsEcr.md
@@ -31,7 +31,11 @@ Using the process that you executed in the previous instruction about how to bui
 
 ⚠️ **Note**: You must have the [AWS CLI installed](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) before you execute the next steps. If you have not done that yet, then go and do it now.
 
-1. Update your [`config.js`](../jwtPizzaServiceContainer/jwtPizzaServiceContainer.md#jwt-pizza-service-container) to reflect the username and password of your [AWS RDS database](../awsRdsMysql/awsRdsMysql.md#db-credentials).
+1. Update your [`config.js`](../jwtPizzaServiceContainer/jwtPizzaServiceContainer.md#jwt-pizza-service-container) with the values from [AWS RDS database](../awsRdsMysql/awsRdsMysql.md#db-credentials) assignment:
+    * `host`: the Amazon Resource Name (ARN) of your database.
+        * i.e. "jwt-pizza-service-db.XXXXXXX.REGION-NAME.rds.amazonaws.com"
+    * `username`: "root"
+    * `password`: the password for your database
 1. Follow the steps that you previously used to build the **jwt-pizza-service** container (including navigating to the `dist` folder before building the container). However, this time specify the target platform of (`linux/arm64`) since that is the operating system you will use when you deploy the container to AWS.
    ```sh
    docker build  --platform=linux/arm64 -t jwt-pizza-service .

--- a/instruction/awsEcr/awsEcr.md
+++ b/instruction/awsEcr/awsEcr.md
@@ -31,6 +31,7 @@ Using the process that you executed in the previous instruction about how to bui
 
 ⚠️ **Note**: You must have the [AWS CLI installed](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) before you execute the next steps. If you have not done that yet, then go and do it now.
 
+1. Update your [`config.js`](../jwtPizzaServiceContainer/jwtPizzaServiceContainer.md#jwt-pizza-service-container) to reflect the username and password of your [AWS RDS database](../awsRdsMysql/awsRdsMysql.md#db-credentials).
 1. Follow the steps that you previously used to build the **jwt-pizza-service** container (including navigating to the `dist` folder before building the container). However, this time specify the target platform of (`linux/arm64`) since that is the operating system you will use when you deploy the container to AWS.
    ```sh
    docker build  --platform=linux/arm64 -t jwt-pizza-service .

--- a/instruction/awsRdsMysql/awsRdsMysql.md
+++ b/instruction/awsRdsMysql/awsRdsMysql.md
@@ -58,6 +58,8 @@ With the network security deployed, you can now create the MySQL server instance
 
       ⚠️ Make sure you don't use anything complicated in your password. The password is communicated as a URL connection string and so many punctuation mark characters will cause the connection to fail. It is best to stick to alphanumeric passwords.
 
+      💡 Leveraging AWS's built-in master password generation feature will help you follow best practices. Note that Amazon will only allow you to see that password **once**. You will need to save it somewhere safe so that you can use it in multiple contexts: 1) manual deployment by hand and 2) automated deployment with the GitHub actions script.
+
 1. Under **Instance configuration**
 
    1. Select `db.t4g.micro` as the DB instance class
@@ -90,6 +92,8 @@ You can solve the network problem by deploying the JWT Pizza service to AWS and 
 Keeping the database on a private network is a good security practice since the database is a high value target that contains user information and credentials.
 
 ### DB credentials
+
+Ultimately, these changed DB credentials will need to end up in your `config.js` file so that your code can communicate with the RDS database. Be prepared to manually inject the value when you manually deploy your code.
 
 To solve the database credential problem, you will store the information necessary to access the database in your `jwt-pizza-service` GitHub Actions secrets. The CI workflow will inject the credentials into the service's configuration when it is deployed.
 

--- a/instruction/deliverable6ScalableDeploy/deliverable6ScalableDeploy.md
+++ b/instruction/deliverable6ScalableDeploy/deliverable6ScalableDeploy.md
@@ -215,6 +215,9 @@ You should now be able to commit and push the workflow script to GitHub. This wi
 
 You should have already followed the [AWS ECS instruction](../awsEcs/awsEcs.md) in order to get your AWS account setup to host the JWT Pizza Service container using Fargate and an application load balancer. Additionally, you should have already set up your [RDS MySQL database](../awsRdsMysql/awsRdsMysql.md). If you have not done this yet, then do so now.
 
+> [!NOTE]
+> When you originally completed the ECS instruction, it was not required that your container correctly communicate with your database. Now that your `config.js` file has been correctly populated with values, your container will have the credentials to hit authorized endpoints!
+
 ## Step 4: Image deployment CI
 
 With ECR configured, the CI workflow for building and pushing a container image to ECR, and ECS configured to deploy a container, you are now ready to enhance the CI workflow to automatically push the container to ECS and update the application load balancer.


### PR DESCRIPTION
## Overview
~Not manually updating the password in the `config.js` file leads to "Circuit Breaker Triggered" errors when deploying services in ECS.~

Using the wrong container architecture leads to a "Circuit Breaker Triggered" error. See the discussion in the comments for an updated understanding of the error (over the information in this PR description).

## Discussion
> [!IMPORTANT]
> The reason for this PR is that the DB connectivity issues caused the container to not start properly which caused the manual deployment to fail which caused the "Circuit Breaker Issue."

The previous instruction modules do provide instruction to  add the DB username and password to GitHub Actions Secrets. This will be required when the deployment happens through that channel, but it does no good for the first manual deployment.

Not performing this step will lead to a `Error occurred during operation 'ECS Deployment Circuit Breaker was triggered'`. Digging in to the issue (through multiple layers of complexities) reveals that the instance is not able to connect to the database which causes it to shut down and fail. After repeatedly attempting to restart the task, the Service will eventually fail to deploy with a less-than-helpful message.

> [!NOTE]
> This PR will merge conflict with #90 since they both modify adjacent lines. I intentionally caused them to modify different lines so that the merge conflict would be as easy to resolve as possible.

## Related Materials
The articles linked to by this change already exist, and one may think that another note about these details isn't necessary. However, not only I, but also other students have faced this error and wondered how to deal with it.

Upon carefully re-reading the  related articles ([RDS](https://github.com/devops329/devops/blob/main/instruction/awsRdsMysql/awsRdsMysql.md), [JWT Pizza Service Container](https://github.com/devops329/devops/blob/main/instruction/jwtPizzaServiceContainer/jwtPizzaServiceContainer.md), [ECR](https://github.com/devops329/devops/blob/main/instruction/awsEcr/awsEcr.md), and [ECS](https://github.com/devops329/devops/blob/main/instruction/awsEcs/awsEcs.md)), the following were observed:
* Students are instructed to save the database password for use in GitHub actions in RDS
* The subsequent Pizza Service Container assignment requires the password to be the localhost password
* The ECR assignment has no discussion about preparing the password for the new environment
* The ECS assignment links to the "Pizza Service Container" assignment loosely. However, this is easy to miss since the majority of the steps in the other page do not need to be followed. (Truly, a student only needs to run the modified build command, **and** update the database username&password.)

## Screenshots

### Cloud Formation
The error displayed from CloudFormation when the service fails to deploy.

<img width="834" alt="Screenshot 2024-11-03 at 1 32 25 AM" src="https://github.com/user-attachments/assets/67df91ca-735e-496b-9ad7-527b87b1b808">

### Elastic Container Service
Logs from ECS which finally pointed towards the actual problem.

<img width="726" alt="image" src="https://github.com/user-attachments/assets/a3383611-a92c-43d1-b51a-3fff728e9839">

