### PR TITLE
Update awsCloudFront.md Indicate outdated CloudFront instructions

### DIFF
--- a/instruction/awsCloudFront/awsCloudFront.md
+++ b/instruction/awsCloudFront/awsCloudFront.md
@@ -79,7 +79,7 @@ With the bucket in place you can now create your CloudFront distribution that wi
 1. For the `Origin domain` start typing the name of the bucket you create. The S3 bucket should appear.
    > ![Origin domain entry](originDomainEntry.png)
 1. In the name edit box, change the name so that it is just your DNS name for simplicity.
-1. Under `Origin access` change from `public`, because our S3 bucket is not public, to **Origin access control settings**. Create a new OAC if you don't already have one, and press `Create`. The OAC allows CloudFront to request private files from S3. This will display a message saying that you need to update the S3 bucket policy. We will do this step later.
+1. Under `Origin access` change from `public`, because our S3 bucket is not public, to ~**Origin access control settings**~ (Origin Request Policy?). Create a new OAC if you don't already have one, and press `Create`. The OAC allows CloudFront to request private files from S3. This will display a message saying that you need to update the S3 bucket policy. We will do this step later.
 1. Skip down to `Default cache behavior`
    1. Under `Viewer protocol policy` specify **Redirect HTTP to HTTPS**
    1. Under `Allowed HTTP methods` specify **GET, HEAD, OPTIONS**.

--- a/instruction/awsCloudFront/awsCloudFront.md
+++ b/instruction/awsCloudFront/awsCloudFront.md
@@ -78,7 +78,6 @@ With the bucket in place you can now create your CloudFront distribution that wi
 1. Press the `Create distribution` button.
 1. For the `Origin domain` start typing the name of the bucket you create. The S3 bucket should appear.
    > ![Origin domain entry](originDomainEntry.png)
-1. In the name edit box, change the name so that it is just your DNS name for simplicity.
 1. Under `Origin access` change from `public`, because our S3 bucket is not public, to ~**Origin access control settings**~ (Origin Request Policy?). Create a new OAC if you don't already have one, and press `Create`. The OAC allows CloudFront to request private files from S3. This will display a message saying that you need to update the S3 bucket policy. We will do this step later.
 1. Skip down to `Default cache behavior`
    1. Under `Viewer protocol policy` specify **Redirect HTTP to HTTPS**


### PR DESCRIPTION
## Background
I think you mentioned in class that AWS had already updated the page since you first created the instruction. Even with my squinty-eyed approach, I think I still did something wrong here.

## Description
> [!IMPORTANT]
> Update: The troubles actually appear to be related to **step number 4** in the instructions. See the "What Did I Do?" section below for a break down of the train of thought and eventual discovery of the problem.

Everything in this file is easy to follow along with, except for this one step (`Origin access`). I hunted through every sub-menu of the page looking for something else that could represent this, and the best I found were the [CloudFront Origin Request Policies](https://console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/policies/origin).

I never did see the yellow banner telling me to update my bucket permissions. I fear I did something wrong— I have a hard time believing that AWS removed a step and that it will just work without these adjustments.

## Screenshot
![image](https://github.com/user-attachments/assets/81c73db6-0776-4514-971c-ff04ec783305)

## Related Resources
After digging around for awhile, I still haven't found the solution, but I suspect that some of these resources may be helpful:
* [AWS Docs: Create Origin Request Policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-request-create-origin-request-policy.html)
* [AWS Docs: Using various origins with CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistS3AndCustomOrigins.html#using-s3-as-origin)
* [AWS Docs: Creating a New Origin Access Control](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html#create-oac-overview-s3)

## What Did I Do?
1. Create the distribution without an OAC
2. Grabbed a template policy from [this support document](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html#create-oac-overview-s3)
3. Followed [these instructions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/add-bucket-policy.html) to add the policy to the S3 bucket
    * The Bucket ARN was easily copiable from the edit page
    * I went to the CloudFront distribution page and copied the ARN for my distribution to fill in the parameter.
4. Continued following the instructions from step 2
5. Found the [Origin Access](https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/originAccess) tab on the CloudFront page.
    * This is different from the [Origin Request Policies](https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/policies/origin) I had originally found
6. These instructions lead me right back to the page that didn't work. 
7. I think I finally figured it out. When applying step number 4 from the class instruction, the Origin Access settings are removed. Reverting to the full URL restores the access settings. See this screenshot:
    * Working settings with the full URL 
    * ![image](https://github.com/user-attachments/assets/569816be-5050-4302-8f3a-b642fbabb34c)
    * Unavailable settings when a portion of the URL is selected
    * ![image](https://github.com/user-attachments/assets/e9859263-ce52-42a2-aa01-a98a5ff12dfc)

