### PR TITLE
Harden github-ci IAM rights (tested)

### DIFF
--- a/instruction/deliverable6ScalableDeploy/deliverable6ScalableDeploy.md
+++ b/instruction/deliverable6ScalableDeploy/deliverable6ScalableDeploy.md
@@ -61,14 +61,23 @@ Next you need to enhance the `github-ci` role rights so that they can push to EC
 
    ```json
    {
+      "Sid": "AuthenticateWithECR",
+      "Effect": "Allow",
+      "Action": "ecr:GetAuthorizationToken",
+      "Resource": "*"
+   },
+   {
       "Sid": "PushToECR",
       "Effect": "Allow",
       "Action": [
-            "ecr:*"
+            "ecr:BatchGetImage",
+            "ecr:BatchCheckLayerAvailability",
+            "ecr:PutImage",
+            "ecr:InitiateLayerUpload",
+            "ecr:UploadLayerPart",
+            "ecr:CompleteLayerUpload"
       ],
-      "Resource": [
-            "*"
-      ]
+      "Resource": "arn:aws:ecr:us-east-1:YOURACCOUNTIDHERE:repository/jwt-pizza-service"
    },
    {
       "Sid": "RegisterTaskDefinition",


### PR DESCRIPTION
## Overview
The original version of these rules demonstrated a really loose `*` wildcard ECR permission.

## Discussion
This changes splits the related ECR permissions into two statements:
1. Grants the permission to authenticate with the platform. This must be granted at the account level rather than a specific repository level.
2. Grants permission to perform the based read/write operations required to efficiently batch update an image. These permissions are only granted for the `jwt-pizza-service` repository in the individuals' account.

You may prefer to have a bad-practice wildcard in the instructions for the purposes of demonstration, but this PR introduces _tested_, hardened IAM rights for the `github-ci` role. It doesn't go crazy deep, but it does restrict the permissions to just the things that are needed.

If you don't want to merge this in, then I'll just count this as an exercise in curiosity and take the blessings for figuring out how to do it :)