### PR TITLE
Resolve 3rd party action security hole

### DIFF
--- a/instruction/deliverable7Environments/ci.yml
+++ b/instruction/deliverable7Environments/ci.yml
@@ -100,7 +100,7 @@ jobs:
       version: ${{needs.build.outputs.version}}
     steps:
       - name: Create staging release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5
         with:
           tag: stage-version-${{ env.version }}
           name: Staging ${{ env.version }}

--- a/instruction/deliverable7Environments/deliverable7Environments.md
+++ b/instruction/deliverable7Environments/deliverable7Environments.md
@@ -370,7 +370,7 @@ Take the following steps in order to create your production release workflow.
          aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/*"
 
      - name: Create production release
-       uses: ncipollo/release-action@v1
+       uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5
        with:
          tag: production-version-${{ env.version }}
          name: Production ${{ env.version }}

--- a/instruction/deliverable7Environments/release.yml
+++ b/instruction/deliverable7Environments/release.yml
@@ -42,7 +42,7 @@ jobs:
           aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/*"
 
       - name: Create production release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5
         with:
           tag: production-version-${{ env.version }}
           name: Production ${{ env.version }}

--- a/instruction/gitHubReleases/gitHubReleases.md
+++ b/instruction/gitHubReleases/gitHubReleases.md
@@ -37,6 +37,8 @@ Since we are DevOps engineers, reading the human-dependent steps above should im
 
 You do this by creating a new workflow job named **release** that triggers when both the build and deploy jobs complete. This job will use the third party `ncipollo/release-action` to call the GitHub API and automatically create the tag and release based upon information found in the execution trigger and the version ID created in the **build** job. You can reference the version variable from the build job with the `needs.build.outputs.version` variable.
 
+> [!NOTE] Blindly using other people's code is a security risk. We have mitigated the risk for our purposes by manually reviewing the code, _and_ by specifying the exact commit from which the action should be used. This gives us confidence that bad actors cannot execute arbitrary code in our workflows by "updating" their source.
+
 Add the following to your `ci.yml` pipeline.
 
 ```yml

--- a/instruction/gitHubReleases/gitHubReleases.md
+++ b/instruction/gitHubReleases/gitHubReleases.md
@@ -47,7 +47,7 @@ release:
   runs-on: ubuntu-latest
   steps:
     - name: Create Release
-      uses: ncipollo/release-action@v1
+      uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5
       env:
         version: ${{needs.build.outputs.version}}
       with:


### PR DESCRIPTION
## Overview
In class, @leesjensen has warned us about the dangers of using 3rd party actions. There is a potential threat that they could update their code to exfiltrate our CI secrets or perform other nefarious actions within our secure context.

## Observation
`ncipollo/release-action@v1` is in the form `<GITHUB_USERNAME>/<REPO_NAME>@SHA` (see [Using tags for [actions] version management](https://docs.github.com/en/actions/sharing-automations/creating-actions/about-custom-actions#using-tags-for-release-management)).

In this case, `v1` is a tag which resolves to a commit.

## Resolution
    Fix the full 40 digit SHA to use from the 3rd party action...
    
    The 'v1' that existed before is a tag which resolves to a SHA.
    This works in industry to get the right version, but a bad actor
    could still reassign that tag to a different commit potentially
    containing nefarious code.
    
    By assigning the full 40 digit SHA, we prevent this kind of attack.
    Tests that attempt to create a 40 digit tag (nefariously) pointing
    to a different commit are foiled. The 'git' system directly uses
    the commit with the full name rather than the tag.
    
    Interestingly, this tag-redirection attack does work on abbreviated
    SHAs. If a particular commit is prefixed with 0a00a74, creating a tag
    with that same name does misdirect the system when performing a
    'git checkout'. For this purpose, we specify the entire 40 digit SHA.

## Correctness
This change was tested and was verified to work. See this [workflow run #12](https://github.com/frozenfrank/jwt-pizza/actions/runs/11725428989/workflow) where the change existed and the jobs all passed.