### PR TITLE
Update grafanaMetrics.md

### DIFF
--- a/instruction/grafanaMetrics/grafanaMetrics.md
+++ b/instruction/grafanaMetrics/grafanaMetrics.md
@@ -165,7 +165,9 @@ In order to send metrics over HTTP you will need an API key.
          ]
       }
    ]
-   }'; done;
+   }'
+     sleep 1;  # Wait 1 second before the next iteration
+   done;
    ```
 
 ## Create a visualization


### PR DESCRIPTION
updated curl command to avoid unnecessary errors in between seconds:  send data to ingesters: failed pushing to ingester ingester-zone-a-100: user=2326245: the sample has been rejected because another sample with the same timestamp, but a different value, has already been ingested (err-mimir-sample-duplicate-timestamp). The affected sample has timestamp 2025-03-16T03:49:29Z and is from series cpu_percent{source="jwt-pizza-service"} (sampled 1/10)