### PR TITLE
Update grafanaMetrics.md

### DIFF
--- a/instruction/grafanaMetrics/grafanaMetrics.md
+++ b/instruction/grafanaMetrics/grafanaMetrics.md
@@ -144,7 +144,7 @@ In order to send metrics over HTTP you will need an API key.
             "metrics": [
                {
                "name": "cpu",
-               "unit": "%",
+               "unit": "s",
                "gauge": {
                   "dataPoints": [
                      {


### PR DESCRIPTION
there's no "cpu_seconds" option, unless we update the curl command like so: