### PR TITLE
Clarify late policy regarding grace days

### DIFF
--- a/instruction/syllabus/syllabus.md
+++ b/instruction/syllabus/syllabus.md
@@ -40,7 +40,7 @@ If you do not have a computer of your own, you can rent one from the [BYU Office
 
 Your success in this course is primarily based upon timely execution. Staying on track results in an enjoyable, positive experience. Once you get behind in the course it is extremely difficult to catch up.
 
-You are given 2 late days at the start of the course. You can gain as many as 2 additional late days for each day that you turn in a deliverable early. Late days are deducted for each day you turn in a deliverable late. If you have zero late days for a late assignment you will receive zero points for that assignment.
+You are given 2 late days at the start of the course. You can gain as many as 2 additional late days for each day that you turn in a deliverable early. Late days are deducted for each day you turn in a deliverable late. If you have zero late days for a late assignment you will receive zero points for that assignment. Grace days cannot be applied retroactively. If you get a bunch of late days at the end of the semester you cannot use them on a previous assignment.
 
 Any assignments not submitted by the last day of class will receive zero points.
 


### PR DESCRIPTION
Added clarification that grace days cannot be applied retroactively and late days cannot be used on previous assignments.