### PR TITLE
Fix typo in JWT Pizza Factory API Key instructions

### DIFF
--- a/instruction/jwtPizzaService/jwtPizzaService.md
+++ b/instruction/jwtPizzaService/jwtPizzaService.md
@@ -50,7 +50,7 @@ Here are the steps to take:
    cd jwt-pizza-service
    npm install
    ```
-1. Obtain a JWT Pizza Factory API Key. You can get this key from the account your created with the [JWT Pizza Factory](https://pizza-factory.cs329.click).
+1. Obtain a JWT Pizza Factory API Key. You can get this key from the account you created with the [JWT Pizza Factory](https://pizza-factory.cs329.click).
 1. Create a `config.js` file in the `src` directory and insert your database credentials, jwtSecret, and API Key. The factory should point to the URL provided by JWT Headquarters. The following is an example `config.js` file.
 
    ```js


### PR DESCRIPTION
Changed "...from the account your created..." to "...from the account you created..."