### PR TITLE
minor semantic fixes

### DIFF
--- a/instruction/jwtPizzaService/jwtPizzaService.md
+++ b/instruction/jwtPizzaService/jwtPizzaService.md
@@ -2,7 +2,7 @@
 
 🔑 **Key points**
 
-- Fork the [JWT Pizza](https://github.com/devops329/jwt-pizza-service) service.
+- Fork the [JWT Pizza Service](https://github.com/devops329/jwt-pizza-service) repository.
 - Study the code.
 
 ---


### PR DESCRIPTION
Include "service" in the hyperlink name and add "repository" at the end for better overall flow